### PR TITLE
Adds in a check for new installs on existing levels

### DIFF
--- a/pmpro-roles.php
+++ b/pmpro-roles.php
@@ -270,7 +270,7 @@ class PMPRO_Roles {
 
 								$checked = '';
 
-								if( isset( $saved_roles[$custom_pmpro_role] ) ){
+								if( isset( $saved_roles[$custom_pmpro_role] ) || empty( $saved_roles ) ){
 									$checked = 'checked=true';
 								}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When installing the Roles Add On for the first time, no roles are selected for a level. This has caused an issue in some cases where a new user signs up and doesn't get a role assigned to them. 

We're now checking if there's no stored value at all, default to the draft PMPro role that we create. 

Relates to #23 

### How to test the changes in this Pull Request:

1. Create a level without the Roles Add On active
2. Install and activate the Roles Add On
3. Edit the level again, no role will be assigned to that level. Saving it won't create the level either. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Bug Fix: We now check if a role has been saved to the level or not
