### PR TITLE
Now using pmpro_after_all_membership_level_changes action

### DIFF
--- a/pmpro-roles.php
+++ b/pmpro-roles.php
@@ -21,7 +21,12 @@ class PMPRO_Roles {
 	function __construct(){
 		add_action( 'pmpro_save_membership_level', array( $this, 'edit_level' ) );
 		add_action( 'pmpro_delete_membership_level', array( $this, 'delete_level' ) );
-		add_action( 'pmpro_after_change_membership_level', array($this, 'user_change_level' ), 10, 2 );
+		if ( version_compare( '2.5.8', PMPRO_VERSION, '>' ) ) {
+			// Use legacy functionality to update roles on level change.
+			add_action( 'pmpro_after_change_membership_level', array($this, 'user_change_level' ), 10, 2 );
+		} else {
+			add_action( 'pmpro_after_all_membership_level_changes', array( $this, 'after_all_level_changes' ), 10, 1 );
+		}
 		add_action( 'admin_enqueue_scripts', array($this, 'enqueue_admin_scripts' ) );
 		add_action( 'wp_ajax_' . PMPRO_Roles::$ajaction, array( $this, 'install' ) );
 		add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( 'PMPRO_Roles', 'add_action_links' ) );
@@ -151,9 +156,79 @@ class PMPRO_Roles {
 			}
 		}
 	}
+
+	/**
+	 * Update users' roles after their membership levels are changed.
+	 *
+	 * @param array $old_user_levels $user_id => array $old_levels
+	 */
+	function after_all_level_changes( $old_user_levels ) {
+		foreach ( $old_user_levels as $user_id => $old_levels ) {
+			// Get the user who changed levels.
+			$user = new WP_User( $user_id );
+
+			// Ignore administrators.
+			if ( in_array( 'administrator', $user->roles ) ) {
+				continue;
+			}
+
+			// Get the user's current active membership levels.
+			$new_levels = pmpro_getMembershipLevelsForUser( $user_id );
+	
+			$new_roles = array();
+			$old_roles = array();
+	
+			// Build an array of all roles assigned to the user's old membership levels.
+			foreach ( $old_levels as $old_level ) {
+				$old_level_roles = get_option( 'pmpro_roles_' . $old_level->id );
+				if ( ! empty( $old_level_roles ) && is_array( $old_level_roles ) ) {
+					$old_roles = array_merge( $old_roles, array_keys( $old_level_roles ) );
+				}
+			}
+	
+			// Build an array of all roles assigned to the user's new membership levels.
+			foreach ( $new_levels as $new_level ) {
+				$new_level_roles = get_option( 'pmpro_roles_' . $new_level->id );
+				if ( ! empty( $new_level_roles ) && is_array( $new_level_roles ) ) {
+					$new_roles = array_merge( $new_roles, array_keys( $new_level_roles ) );
+				}
+			}
+	
+			// Remove duplicates in the array of old and new roles.
+			$old_roles = array_unique( $old_roles );		
+			$new_roles = array_unique( $new_roles );
+	
+			// Build a unique array of roles to add and remove from user.
+			$add_roles = $new_roles;
+			$remove_roles = array_values( array_diff( $old_roles, $new_roles ) );
+
+			// Add roles to user.
+			foreach ( $add_roles as $add_role ) {
+				$user->add_role( $add_role );
+			}
+	
+			// Remove roles from user.
+			foreach ( $remove_roles as $remove_role ) {
+				$user->remove_role( $remove_role );
+			}
+
+			// Handle case where role can be "simplified" to a single role.
+			$default_role = apply_filters( 'pmpro_roles_downgraded_role', get_option( 'default_role' ) );
+			if ( in_array( $default_role, $user->roles, true ) && count( $user->roles ) == 2 ) {
+				$user->remove_role( $default_role );
+			}
+
+			// Handle case where user has no role.
+			if ( empty( $user->roles ) ) {
+				$user->add_role( $default_role );
+			}
+		}
+	}
 	
 	/**
 	 * Change user role based on level change. (Now supports MMPU)
+	 * No longer being used if PMPro version >= 2.5.8.
+	 *
 	 * @since 1.0
 	 */
 	function user_change_level($level_id, $user_id){


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now using `pmpro_after_all_membership_level_changes` action instead of `pmpro_after_change_membership_level`. This allows for better compatibility with MMPU and 3rd party plugins that change membership level, such as WooCommerce.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #24.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
