### PR TITLE
Fixes critical error when PMPro is inactive

### DIFF
--- a/pmpro-roles.php
+++ b/pmpro-roles.php
@@ -21,7 +21,7 @@ class PMPRO_Roles {
 	function __construct(){
 		add_action( 'pmpro_save_membership_level', array( $this, 'edit_level' ) );
 		add_action( 'pmpro_delete_membership_level', array( $this, 'delete_level' ) );
-		if ( version_compare( '2.5.8', PMPRO_VERSION, '>' ) ) {
+		if ( defined( 'PMPRO_VERSION' ) && version_compare( '2.5.8', PMPRO_VERSION, '>' ) ) {
 			// Use legacy functionality to update roles on level change.
 			add_action( 'pmpro_after_change_membership_level', array($this, 'user_change_level' ), 10, 2 );
 		} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added in a check to make sure the PMPRO_VERSION constant is defined before we use it

Resolves #34.

### How to test the changes in this Pull Request:

1. Activate PMPro Core
2. Activate PMPro Roles
3. Deactivate PMPro Core - no error should show now

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Bug Fix: Fixed a critical error that occurred when Paid Memberships Pro was deactivated
