### PR TITLE
Update headings hierarchy for a11y

### DIFF
--- a/pmpro-roles.php
+++ b/pmpro-roles.php
@@ -352,7 +352,7 @@ class PMPRO_Roles {
 		?>
 		<hr />
 
-		<h3><?php esc_html_e( 'Role Settings', 'pmpro-roles' ); ?></h3>
+		<h2><?php esc_html_e( 'Role Settings', 'pmpro-roles' ); ?></h2>
 		<p class="description">
 			<?php
 				$allowed_pmpro_roles_description_html = array (


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.
