### PR TITLE
Default to site default role

### DIFF
--- a/pmpro-roles.php
+++ b/pmpro-roles.php
@@ -109,13 +109,12 @@ class PMPRO_Roles {
 		
 		$roles = get_option( self::$plugin_prefix . $level_id );
 		
-		// Default to the role created for this level.
+		// Default to the site role, if no role is found.
 		if ( empty( $roles ) ) {			
-			$roles = array();			
-			$level = pmpro_getLevel( $level_id );
-			if ( ! empty( $level ) ) {
-				$roles[ self::$role_key . $level_id ] = $level->name;
-			}			
+			$roles = array();
+			$default_role = get_option( 'default_role' );					
+			$roles[ $default_role ] = ucfirst( $default_role );
+			
 		}
 		
 		return $roles;

--- a/pmpro-roles.php
+++ b/pmpro-roles.php
@@ -145,7 +145,7 @@ class PMPRO_Roles {
 			}
 			
 			//created a new level, lets try to create all the roles necessary.
-			if( $_REQUEST['edit'] < 0 ) {
+			if ( isset( $_REQUEST['edit'] ) && $_REQUEST['edit'] < 0 ) {
 				foreach( $level_roles as $role_key => $role_name ){
 					if ( $role_key === 'pmpro_role_'. $saveid ) {
 						$capabilities = PMPRO_Roles::capabilities( $role_key );

--- a/pmpro-roles.php
+++ b/pmpro-roles.php
@@ -364,7 +364,8 @@ class PMPRO_Roles {
 						'title' => array(),
 					),
 				);
-				echo sprintf( wp_kses( __( 'Choose one or more roles to be assigned for members of this level. <a href="%s" title="Paid Memberships Pro - Roles Add On" target="_blank">Visit the documentation page</a> for more information.', 'pmpro-roles' ), $allowed_pmpro_roles_description_html ), 'https://www.paidmembershipspro.com/add-ons/pmpro-roles//?utm_source=plugin&utm_medium=pmpro-membershiplevels&utm_campaign=add-ons&utm_content=pmpro-roles' );
+				echo sprintf( wp_kses( __( 'Choose one or more roles to be assigned for members of this level. <a href="%s" title="Paid Memberships Pro - Roles Add On" target="_blank">Visit the documentation page</a> for more information.', 'pmpro-roles' ), $allowed_pmpro_roles_description_html ), 'https://www.paidmembershipspro.com/add-ons/pmpro-roles//?utm_source=plugin&utm_medium=pmpro-membershiplevels&utm_campaign=add-ons&utm_content=pmpro-roles' );				
+				echo '<p>' . esc_html__( 'If you do not select a custom role for users of this membership level, the user will be assigned the "New User Default Role" as defined under Settings > General in the WordPress admin', 'pmpro-roles' ) . '</p>';
 			?>
 		</p>
 		<table class="form-table">


### PR DESCRIPTION
* ENHANCEMENT: Added the ability to create the pmpro_role_<<level_id>> when we detect the level doesn't have this role created and not only on initial level creation.
* ENHANCEMENT: If no role is selected for a level, it automatically selects the sites default user role and doesn't create the custom role anymore.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

