### PR TITLE
Fix warning about $_REQUEST['edit'] missing

### DIFF
--- a/pmpro-roles.php
+++ b/pmpro-roles.php
@@ -140,7 +140,7 @@ class PMPRO_Roles {
 			}
 
 			//created a new level
-			if( $_REQUEST['edit'] < 0 ) {
+			if ( ! empty( $_REQUEST['edit'] ) && $_REQUEST['edit'] < 0 ) {
 				foreach( $level_roles as $role_key => $role_name ){
 					if( $role_key === 'pmpro_draft_role' ){						
 						add_role( PMPRO_Roles::$role_key.$saveid, sanitize_text_field( $_REQUEST['name'] ), array( 'read' => true ) );	


### PR DESCRIPTION
* BUG FIX: Fixed a warning that 'edit' was undefined when trying to get the parameter from the URL.
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
