### PR TITLE
Remove the draft role on plugin deletion

### DIFF
--- a/pmpro-roles.php
+++ b/pmpro-roles.php
@@ -693,6 +693,9 @@ class PMPRO_Roles {
 			}
 		}
 
+		// Remove the pmpro_draft_role if it exists.
+		remove_role( 'pmpro_draft_role' );
+		
 		//deactivate the plugin
 		deactivate_plugins( plugin_basename( __FILE__ ) );
 


### PR DESCRIPTION
* BUG FIX: Fixed an issue where in some cases the draft_role is created but not removed. Now it is removed whenever you "Delete and deactivate" on the plugins installation page.
