### PR TITLE
When payment is "pending" do not assign roles.

### DIFF
--- a/pmpro-roles.php
+++ b/pmpro-roles.php
@@ -261,6 +261,11 @@ class PMPRO_Roles {
 			// Remove duplicates in the array of old and new roles.
 			$old_roles = array_unique( $old_roles );		
 			$new_roles = array_unique( $new_roles );
+
+			// Don't assign new roles when membership is pending from using the Pay By Check add-on
+			if ( pmpropbc_isMemberPending( $user_id ) ) {
+				$new_roles = $old_roles;
+			}
 	
 			// Build a unique array of roles to add and remove from user.
 			$add_roles = $new_roles;


### PR DESCRIPTION
Adds some code in the after_all_level_changes function using pmpropbc_isMemberPending to prevent new roles from being assigned to user.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Stops new roles from being assigned when membership is pending from using the Pay By Check add-on. This partially resolves issue #36. I say partially because this does not assign roles when payment is marked "success".

### How to test the changes in this Pull Request:

1. Install Pay By Check add-on
2. Check out with a new membership level, use the "pay by check" option for payment
3. The new member that signed up using "pay by check" will now only have their old role(s) instead of being automatically assigned all the new roles that comes with their new membership level

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

ENHANCEMENT: when membership is pending, the pending member will only be assigned old roles. New roles will not be assigned.
