### PR TITLE
Require manage_options for the delete and deactivate action

### DIFF
--- a/pmpro-roles.php
+++ b/pmpro-roles.php
@@ -667,8 +667,8 @@ class PMPRO_Roles {
 	 * @since 1.0
 	 */
 	public static function add_action_links($links) {	
-		// Only add this if plugin is active.
-		if( is_plugin_active( 'pmpro-roles/pmpro-roles.php' ) ) {
+		// Only add this if plugin is active and the user can run the action.
+		if( is_plugin_active( 'pmpro-roles/pmpro-roles.php' ) && current_user_can( 'manage_options' ) ) {
 			$new_links = array(
 				'<a href="' . wp_nonce_url(get_admin_url(NULL, 'plugins.php?pmpro_roles_delete_and_deactivate=1'), 'pmpro_roles_delete_and_deactivate') . '">' . esc_html__( 'Delete Roles and Deactivate', 'pmpro-roles' ) . '</a>',
 			);

--- a/pmpro-roles.php
+++ b/pmpro-roles.php
@@ -700,6 +700,10 @@ class PMPRO_Roles {
 		if(empty($_REQUEST['pmpro_roles_delete_and_deactivate']))
 			return;
 
+		//check capability
+		if(!current_user_can('manage_options'))
+			return;
+
 		//check nonce
 		check_admin_referer('pmpro_roles_delete_and_deactivate');
 		


### PR DESCRIPTION
The delete-and-deactivate handler verified a nonce but never asserted a capability. Adds an explicit `manage_options` check before the nonce verification, matching the capability required to see the plugins page where the action link is shown.

**Testing:** use the "delete role assignments and deactivate" link as an admin (works as before).